### PR TITLE
Fix trismik dependency issue by adding version constraint

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6615,4 +6615,4 @@ vertex = ["fsspec", "google-cloud-storage", "google-genai", "pandas", "python-do
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "cee7c7c3544dfa18049dc8eed5bdf4d460f3219b23fe133cda5593422c4531b1"
+content-hash = "6682f05b70b4d6ed2bff04aad67c62e79912b87f3d6b02e945f59a91d6b8af0d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,14 @@ requires-python = ">=3.9"
 dependencies = [
     "datasets>=3.6.0",
     "notebook (>=7.4.5,<8.0.0)",
-    "trismik",
+    "trismik>=0.9.3rc3",
 ]
 
 [project.scripts]
 scorebook = "scorebook.cli.main:main"
 
 [tool.poetry]
-version = "0.0.5"  # base version
+version = "0.0.6"  # base version
 packages = [{ include = "scorebook", from = "src" }]
 
 [[tool.poetry.source]]


### PR DESCRIPTION
Add minimum version requirement for trismik>=0.9.3rc3 to ensure the adaptive_test module is available. This resolves import errors in downstream projects that were getting older versions of trismik.

Bump version to 0.0.6.

🤖 Generated with [Claude Code](https://claude.ai/code)