### PR TITLE
Implement separate async evaluation functionality

### DIFF
--- a/src/scorebook/__init__.py
+++ b/src/scorebook/__init__.py
@@ -10,9 +10,17 @@ import importlib.metadata
 __version__ = importlib.metadata.version(__package__ or __name__)
 
 from scorebook.eval_dataset import EvalDataset
-from scorebook.evaluate import evaluate
+from scorebook.evaluate import evaluate, evaluate_async
 from scorebook.inference_pipeline import InferencePipeline
 from scorebook.trismik_services.login import login, whoami
 from scorebook.utils.build_prompt import build_prompt
 
-__all__ = ["EvalDataset", "evaluate", "build_prompt", "login", "whoami", "InferencePipeline"]
+__all__ = [
+    "EvalDataset",
+    "evaluate",
+    "evaluate_async",
+    "build_prompt",
+    "login",
+    "whoami",
+    "InferencePipeline",
+]


### PR DESCRIPTION
- Add evaluate_async function for native async evaluation
- Separate sync and async execution paths in evaluation pipeline
- Update InferencePipeline to dynamically switch between sync/async classes
- Simplify progress bar tracking by removing parallel mode distinctions
- Export evaluate_async in package __init__ for public API
- Maintain backward compatibility with existing evaluate function
- Fix sync evaluate to properly handle async inference functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)