### PR TITLE
Exclude auto-generated _sync code from linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,18 +15,21 @@ repos:
     rev: 24.3.0
     hooks:
     -   id: black
+        exclude: ^src/scorebook/evaluate/_sync/
 
 -   repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1
     hooks:
     -   id: autoflake
         args: [--remove-all-unused-imports, --in-place, --recursive, .]
+        exclude: ^src/scorebook/evaluate/_sync/
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
     -   id: isort
         args: ["--profile", "black"]
+        exclude: ^src/scorebook/evaluate/_sync/
 
 -   repo: https://github.com/pycqa/flake8
     rev: 7.0.0
@@ -36,7 +39,7 @@ repos:
         args: [
             "--max-line-length=100",
             "--extend-ignore=E203",
-            "--exclude=.git,__pycache__,build,dist",
+            "--exclude=.git,__pycache__,build,dist,src/scorebook/evaluate/_sync",
             "--per-file-ignores=__init__.py:F401,tests/*.py:D100,D101,D102,D103,D104"
         ]
 
@@ -45,10 +48,16 @@ repos:
     hooks:
     -   id: mypy
         additional_dependencies: [types-python-dateutil, types-PyYAML]
-        exclude: "tests/.*\\.py"
+        exclude: "(tests/.*\\.py|src/scorebook/evaluate/_sync/.*\\.py)"
 
 -   repo: local
     hooks:
+    -   id: generate-sync
+        name: Generate sync code from async
+        entry: python scripts/generate_sync.py
+        language: system
+        pass_filenames: false
+        files: ^src/scorebook/evaluate/_async/.*\.py$
     -   id: pytest
         name: pytest
         entry: poetry run pytest


### PR DESCRIPTION
Add exclusions for src/scorebook/evaluate/_sync/ directory to prevent linting auto-generated synchronous code. This includes:
- black, autoflake, isort, flake8, and mypy exclusions
- New generate-sync pre-commit hook to regenerate sync code

🤖 Generated with [Claude Code](https://claude.com/claude-code)